### PR TITLE
Inlay Hints: Change fn arg(s) tooltip(s) to display the target type

### DIFF
--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -332,7 +332,7 @@ fn functionTypeCompletion(
                     .parameters = .{ .show = .{
                         .include_modifiers = true,
                         .include_names = true,
-                        .include_types = true,
+                        .include_types = false,
                     } },
                     .include_return_type = false,
                     .snippet_placeholders = true,

--- a/src/tools/config.json
+++ b/src/tools/config.json
@@ -72,18 +72,6 @@
             "default": true
         },
         {
-            "name": "inlay_hints_hide_redundant_param_names",
-            "description": "Hides inlay hints when parameter name matches the identifier (e.g. foo: foo)",
-            "type": "bool",
-            "default": false
-        },
-        {
-            "name": "inlay_hints_hide_redundant_param_names_last_token",
-            "description": "Hides inlay hints when parameter name matches the last token of a parameter node (e.g. foo: bar.foo, foo: &foo)",
-            "type": "bool",
-            "default": false
-        },
-        {
             "name": "warn_style",
             "description": "Enables warnings for style guideline mismatches",
             "type": "bool",

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -3115,8 +3115,8 @@ test "insert replace behaviour - builtin with snippets" {
     try testCompletionTextEdit(.{
         .source = "const foo = @<cursor>;",
         .label = "@as",
-        .expected_insert_line = "const foo = @as(${1:comptime T: type}, ${2:expression});",
-        .expected_replace_line = "const foo = @as(${1:comptime T: type}, ${2:expression});",
+        .expected_insert_line = "const foo = @as(${1:comptime T}, ${2:expression});",
+        .expected_replace_line = "const foo = @as(${1:comptime T}, ${2:expression});",
         .enable_snippets = true,
         .enable_argument_placeholders = true,
     });
@@ -3131,8 +3131,8 @@ test "insert replace behaviour - builtin with snippets" {
     try testCompletionTextEdit(.{
         .source = "const foo = @<cursor>();",
         .label = "@as",
-        .expected_insert_line = "const foo = @as(${1:comptime T: type}, ${2:expression});",
-        .expected_replace_line = "const foo = @as(${1:comptime T: type}, ${2:expression});",
+        .expected_insert_line = "const foo = @as(${1:comptime T}, ${2:expression});",
+        .expected_replace_line = "const foo = @as(${1:comptime T}, ${2:expression});",
         .enable_snippets = true,
         .enable_argument_placeholders = true,
     });
@@ -3177,8 +3177,8 @@ test "insert replace behaviour - builtin with partial argument placeholders" {
     try testCompletionTextEdit(.{
         .source = "const foo = @<cursor>( , 5);",
         .label = "@as",
-        .expected_insert_line = "const foo = @as(${1:comptime T: type}, 5);",
-        .expected_replace_line = "const foo = @as(${1:comptime T: type}, 5);",
+        .expected_insert_line = "const foo = @as(${1:comptime T}, 5);",
+        .expected_replace_line = "const foo = @as(${1:comptime T}, 5);",
         .enable_snippets = true,
         .enable_argument_placeholders = true,
     });
@@ -3345,8 +3345,8 @@ test "insert replace behaviour - function with snippets" {
         \\const foo = <cursor>;
         ,
         .label = "func",
-        .expected_insert_line = "const foo = func(${1:comptime T: type}, ${2:number: u32});",
-        .expected_replace_line = "const foo = func(${1:comptime T: type}, ${2:number: u32});",
+        .expected_insert_line = "const foo = func(${1:comptime T}, ${2:number});",
+        .expected_replace_line = "const foo = func(${1:comptime T}, ${2:number});",
         .enable_snippets = true,
         .enable_argument_placeholders = true,
     });
@@ -3367,8 +3367,8 @@ test "insert replace behaviour - function with snippets" {
         \\const foo = <cursor>();
         ,
         .label = "func",
-        .expected_insert_line = "const foo = func(${1:comptime T: type}, ${2:number: u32});",
-        .expected_replace_line = "const foo = func(${1:comptime T: type}, ${2:number: u32});",
+        .expected_insert_line = "const foo = func(${1:comptime T}, ${2:number});",
+        .expected_replace_line = "const foo = func(${1:comptime T}, ${2:number});",
         .enable_snippets = true,
         .enable_argument_placeholders = true,
     });
@@ -3381,8 +3381,8 @@ test "insert replace behaviour - function with snippets" {
         \\S.<cursor>
         ,
         .label = "f",
-        .expected_insert_line = "S.f(${1:self: S})",
-        .expected_replace_line = "S.f(${1:self: S})",
+        .expected_insert_line = "S.f(${1:self})",
+        .expected_replace_line = "S.f(${1:self})",
         .enable_snippets = true,
         .enable_argument_placeholders = true,
     });
@@ -3396,8 +3396,8 @@ test "insert replace behaviour - function with snippets" {
         \\s.<cursor>
         ,
         .label = "f",
-        .expected_insert_line = "s.f(${1:number: u32})",
-        .expected_replace_line = "s.f(${1:number: u32})",
+        .expected_insert_line = "s.f(${1:number})",
+        .expected_replace_line = "s.f(${1:number})",
         .enable_snippets = true,
         .enable_argument_placeholders = true,
     });
@@ -3464,8 +3464,8 @@ test "insert replace behaviour - function with partial argument placeholders" {
         \\const foo = <cursor>(u32,);
         ,
         .label = "func",
-        .expected_insert_line = "const foo = func(u32, ${1:number: u32});",
-        .expected_replace_line = "const foo = func(u32, ${1:number: u32});",
+        .expected_insert_line = "const foo = func(u32, ${1:number});",
+        .expected_replace_line = "const foo = func(u32, ${1:number});",
         .enable_snippets = true,
         .enable_argument_placeholders = true,
     });
@@ -3475,8 +3475,8 @@ test "insert replace behaviour - function with partial argument placeholders" {
         \\const foo = <cursor>( , 5);
         ,
         .label = "func",
-        .expected_insert_line = "const foo = func(${1:comptime T: type}, 5);",
-        .expected_replace_line = "const foo = func(${1:comptime T: type}, 5);",
+        .expected_insert_line = "const foo = func(${1:comptime T}, 5);",
+        .expected_replace_line = "const foo = func(${1:comptime T}, 5);",
         .enable_snippets = true,
         .enable_argument_placeholders = true,
     });


### PR DESCRIPTION
Affects: `inlay_hints_show_parameter_name`'s behavior

The intention was to address a frequent (to me) annoyance: When auto-completing a fncall the server inserts `param_name :ParamType`. This is all very helpful, except that the parser bails out at the `:`, which ends up affecting all nodes within the immediate scope(s), eg `const descriptive_name = ..`, `var complex_result = some()`, ... you know, the ones you intended to pass as args to the very same fn call.

The server now inserts only `param_name`

Consequently, this left a void - previously target types were, briefly, known at a glance (and even if you knew them, you'd simply be certain).

Argument hints now display the expected/target type

Eliminates `inlay_hints_hide_redundant_param_names` and
           `inlay_hints_hide_redundant_param_names_last_token`

Feels like a neat solution, plus, I, for one, am relieved to no longer have to name match my args (especially if I had named the params). The trade-off: lines are longer.. :face_with_spiral_eyes:

Could use a few tweaks, but the solution to those will become apparent after some mileage.

Setting's name stays the same for compatibility with upstream.