### PR TITLE
Update to Zig 0.14.0-dev.1983+6bf52b050

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -7,8 +7,8 @@ const proj_version = std.SemanticVersion{ .major = 0, .minor = 14, .patch = 0, .
 
 /// Specify the minimum Zig version that is required to compile and test the project:
 /// Must match the `minimum_zig_version` in `build.zig.zon`.
-/// Breaking change summary: std.zig.tokenizer: simplify line-based tokens
-const minimum_build_zig_version = "0.14.0-dev.1517+900753455";
+/// Breaking change summary: Replace `std.builtin.CallingConvention` with a tagged union, eliminating `@setAlignStack`
+const minimum_build_zig_version = "0.14.0-dev.1983+6bf52b050";
 
 /// Specify the minimum Zig version that is required to run the project:
 /// Release 0.12.0

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,7 +3,7 @@
     // Must match the `proj_version` in `build.zig`
     .version = "0.14.0-dev",
     // Must match the `minimum_build_zig_version` in `build.zig`
-    .minimum_zig_version = "0.14.0-dev.1517+900753455",
+    .minimum_zig_version = "0.14.0-dev.1983+6bf52b050",
     .dependencies = .{
         .known_folders = .{
             .url = "https://github.com/ziglibs/known-folders/archive/1cceeb70e77dec941a4178160ff6c8d05a74de6f.tar.gz",

--- a/src/analyser/InternPool.zig
+++ b/src/analyser/InternPool.zig
@@ -125,7 +125,7 @@ pub const Key = union(enum) {
         flags: Flags = .{},
 
         pub const Flags = packed struct(u32) {
-            calling_convention: std.builtin.CallingConvention = .Unspecified,
+            calling_convention: std.builtin.CallingConvention.Tag = .auto,
             is_generic: bool = false,
             is_var_args: bool = false,
             _: u6 = 0,
@@ -1098,8 +1098,8 @@ pub fn init(gpa: Allocator) Allocator.Error!InternPool {
         .{ .index = .manyptr_const_u8_sentinel_0_type, .key = .{ .pointer_type = .{ .elem_type = .u8_type, .sentinel = .zero_u8, .flags = .{ .size = .Many, .is_const = true } } } },
         .{ .index = .fn_noreturn_no_args_type, .key = .{ .function_type = .{ .args = Index.Slice.empty, .return_type = .noreturn_type } } },
         .{ .index = .fn_void_no_args_type, .key = .{ .function_type = .{ .args = Index.Slice.empty, .return_type = .void_type } } },
-        .{ .index = .fn_naked_noreturn_no_args_type, .key = .{ .function_type = .{ .args = Index.Slice.empty, .return_type = .void_type, .flags = .{ .calling_convention = .Naked } } } },
-        .{ .index = .fn_ccc_void_no_args_type, .key = .{ .function_type = .{ .args = Index.Slice.empty, .return_type = .void_type, .flags = .{ .calling_convention = .C } } } },
+        .{ .index = .fn_naked_noreturn_no_args_type, .key = .{ .function_type = .{ .args = Index.Slice.empty, .return_type = .void_type, .flags = .{ .calling_convention = .naked } } } },
+        .{ .index = .fn_ccc_void_no_args_type, .key = .{ .function_type = .{ .args = Index.Slice.empty, .return_type = .void_type, .flags = .{ .calling_convention = builtin.target.cCallingConvention().? } } } },
         .{ .index = .single_const_pointer_to_comptime_int_type, .key = .{ .pointer_type = .{ .elem_type = .comptime_int_type, .flags = .{ .size = .One, .is_const = true } } } },
         .{ .index = .slice_const_u8_type, .key = .{ .pointer_type = .{ .elem_type = .u8_type, .flags = .{ .size = .Slice, .is_const = true } } } },
         .{ .index = .slice_const_u8_sentinel_0_type, .key = .{ .pointer_type = .{ .elem_type = .u8_type, .sentinel = .zero_u8, .flags = .{ .size = .Slice, .is_const = true } } } },
@@ -3952,7 +3952,7 @@ fn printInternal(ip: *InternPool, ty: Index, writer: anytype, options: FormatOpt
             if (function_info.flags.alignment != 0) {
                 try writer.print("align({d}) ", .{function_info.flags.alignment});
             }
-            if (function_info.flags.calling_convention != .Unspecified) {
+            if (function_info.flags.calling_convention != .auto) {
                 try writer.print("callconv(.{s}) ", .{@tagName(function_info.flags.calling_convention)});
             }
 

--- a/src/analyser/InternPool.zig
+++ b/src/analyser/InternPool.zig
@@ -2450,8 +2450,8 @@ const InMemoryCoercionResult = union(enum) {
     };
 
     const CC = struct {
-        actual: std.builtin.CallingConvention,
-        wanted: std.builtin.CallingConvention,
+        actual: std.builtin.CallingConvention.Tag,
+        wanted: std.builtin.CallingConvention.Tag,
     };
 
     const BitRange = struct {
@@ -4532,19 +4532,26 @@ test "function type" {
         },
     } });
 
-    const @"fn() align(4) callconv(.C) type" = try ip.get(gpa, .{ .function_type = .{
+    try expectFmt("fn(i32) bool", "{}", .{@"fn(i32) bool".fmt(&ip)});
+    try expectFmt("fn(comptime type, noalias i32) type", "{}", .{@"fn(comptime type, noalias i32) type".fmt(&ip)});
+    try expectFmt("fn(i32, ...) type", "{}", .{@"fn(i32, ...) type".fmt(&ip)});
+
+    const @"fn() align(4) callconv(<c>) type" = try ip.get(gpa, .{ .function_type = .{
         .args = Index.Slice.empty,
         .return_type = .type_type,
         .flags = .{
-            .calling_convention = .C,
+            .calling_convention = std.builtin.CallingConvention.c,
             .alignment = 4,
         },
     } });
 
-    try expectFmt("fn(i32) bool", "{}", .{@"fn(i32) bool".fmt(&ip)});
-    try expectFmt("fn(comptime type, noalias i32) type", "{}", .{@"fn(comptime type, noalias i32) type".fmt(&ip)});
-    try expectFmt("fn(i32, ...) type", "{}", .{@"fn(i32, ...) type".fmt(&ip)});
-    try expectFmt("fn() align(4) callconv(.C) type", "{}", .{@"fn() align(4) callconv(.C) type".fmt(&ip)});
+    try expectFmt(
+        std.fmt.comptimePrint("fn() align(4) callconv(.{s}) type", .{@tagName(std.builtin.CallingConvention.c)}),
+        "{}",
+        .{
+            @"fn() align(4) callconv(<c>) type".fmt(&ip),
+        },
+    );
 }
 
 test "union value" {

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -1262,6 +1262,7 @@ fn getSwitchOrStructInitContext(
                                     if (parens_depth == one_opening and switch (token_tags[upper_index - 1]) {
                                         .identifier,
                                         .builtin,
+                                        .keyword_callconv,
                                         => true,
                                         else => false,
                                     }) {

--- a/src/zig-components/parser_test.zig
+++ b/src/zig-components/parser_test.zig
@@ -107,15 +107,15 @@ test "zig fmt: respect line breaks before functions" {
     );
 }
 
-test "zig fmt: rewrite callconv(.Inline) to the inline keyword" {
+test "zig fmt: rewrite callconv(.@\"inline\") to the inline keyword" {
     try testTransform(
-        \\fn foo() callconv(.Inline) void {}
-        \\const bar = .Inline;
+        \\fn foo() callconv(.@"inline") void {}
+        \\const bar: @import("std").builtin.CallingConvention = .@"inline";
         \\fn foo() callconv(bar) void {}
         \\
     ,
         \\inline fn foo() void {}
-        \\const bar = .Inline;
+        \\const bar: @import("std").builtin.CallingConvention = .@"inline";
         \\fn foo() callconv(bar) void {}
         \\
     );
@@ -3043,7 +3043,7 @@ test "zig fmt: functions" {
         \\pub export fn puts(s: *const u8) align(2 + 2) c_int;
         \\pub inline fn puts(s: *const u8) align(2 + 2) c_int;
         \\pub noinline fn puts(s: *const u8) align(2 + 2) c_int;
-        \\pub fn callInlineFn(func: fn () callconv(.Inline) void) void {
+        \\pub fn callInlineFn(func: fn () callconv(.@"inline") void) void {
         \\    func();
         \\}
         \\

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -2773,6 +2773,12 @@ test "builtin fns taking an enum arg" {
         .expected_insert_line = "fn foo() callconv(.AAPCS",
         .expected_replace_line = "fn foo() callconv(.AAPCS",
     });
+    try testCompletionTextEdit(.{
+        .source = "fn foo() callconv(.{ .x86_64_sysv = .<cursor>",
+        .label = "incoming_stack_alignment",
+        .expected_insert_line = "fn foo() callconv(.{ .x86_64_sysv = .{ .incoming_stack_alignment = ",
+        .expected_replace_line = "fn foo() callconv(.{ .x86_64_sysv = .{ .incoming_stack_alignment = ",
+    });
 }
 
 test "block" {


### PR DESCRIPTION
Fix for `0.14.0-dev.1983+6bf52b050`

`std.builtin.CallingConvention` was recently changed to `union(enum(u8))`, with some deprecated names as well. This swaps the field to be `CallingConvention.Tag` type instead and replaces the deprecated names with their equivalent 
